### PR TITLE
update composer.json to reflect actual package usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
   "license": "proprietary",
   "require": {
     "php": "^7.1",
-    "symfony/framework-bundle": "^3.4",
+    "symfony/config": "^3.2 || ^4.0",
+    "symfony/dependency-injection": "^3.2 || ^4.0",
+    "symfony/http-kernel": "^3.2 || ^4.0",
     "contao/core-bundle": "^4.4",
     "heimrichhannot/contao-utils-bundle": "^2.28"
   },


### PR DESCRIPTION
The `symfony/framework-bundle` isn't actually used in this package - and it restricts to Symfony 3, which makes the installation in Contao 4.7+ more difficult. I also added other symfony packages, that are actually used by this bundle.